### PR TITLE
KUBOS-131 HAL Unit Tests + misc

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1951,7 +1951,7 @@ PERLMOD_MAKEVAR_PREFIX =
 # C-preprocessor directives found in the sources and include files.
 # The default value is: YES.
 
-ENABLE_PREPROCESSING   = YES
+ENABLE_PREPROCESSING   = NO
 
 # If the MACRO_EXPANSION tag is set to YES, doxygen will expand all macro names
 # in the source code. If set to NO, only conditional compilation will be

--- a/docs/main.md
+++ b/docs/main.md
@@ -3,3 +3,5 @@
 ### API Modules:
  - @subpage GPIO
  - @subpage UART
+ - @subpage I2C
+ - @subpage SPI

--- a/kubos-hal-msp430f5529/uart.h
+++ b/kubos-hal-msp430f5529/uart.h
@@ -1,0 +1,31 @@
+/*
+ * KubOS HAL
+ * Copyright (C) 2016 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if (defined YOTTA_CFG_HARDWARE_UART) && (YOTTA_CFG_HARDWARE_UART_COUNT > 0)
+#ifndef K_UART_H
+#define K_UART_H
+
+#include "kubos-hal/uart.h"
+
+/**
+ * Internal function to get appropriate uart handle based on uart num
+ * @param uart uart bus num
+ * @return hal_uart_handle pointer
+ */
+hal_uart_handle * uart_handle(KUARTNum uart)
+
+#endif
+#endif

--- a/source/i2c.c
+++ b/source/i2c.c
@@ -104,7 +104,7 @@ KI2CStatus kprv_i2c_dev_init(KI2CNum i2c)
             .role = i2c_role(k_i2c->conf.role)
     };
 
-    hal_i2c_handle * handle = hal_i2c_init(config, i2c);
+    hal_i2c_handle * handle = hal_i2c_init(config, i2c_bus(i2c));
     if (handle != NULL)
     {
         handle->bus_num = i2c_bus(i2c);

--- a/source/i2c.c
+++ b/source/i2c.c
@@ -98,6 +98,16 @@ KI2CStatus kprv_i2c_dev_init(KI2CNum i2c)
         return I2C_ERROR_NULL_HANDLE;
     }
 
+    /*
+     * We don't currently support slave mode.  Initialization should fail
+     * if it's specified.
+     * Remove this once slave mode is implemented.
+     */
+    if(k_i2c->conf.role == K_SLAVE)
+    {
+        return I2C_ERROR;
+    }
+
     hal_i2c_config config = {
             .addressing_mode = i2c_addressing(k_i2c->conf.addressing_mode),
             .clock_speed = k_i2c->conf.clock_speed,

--- a/source/i2c.c
+++ b/source/i2c.c
@@ -87,9 +87,10 @@ static inline hal_i2c_role i2c_role(I2CRole role)
 }
 
 /**
-  * @brief Creates and sets up specified i2c bus option.
-  * @param i2c Number of i2c bus to setup.
-  */
+ * Setup and enable i2c bus
+ * @param i2c i2c bus to initialize
+ * @return KI2CStatus I2C_OK if success, otherwise a specific error flag
+ */
 KI2CStatus kprv_i2c_dev_init(KI2CNum i2c)
 {
     KI2C *k_i2c = kprv_i2c_get(i2c);
@@ -124,6 +125,11 @@ KI2CStatus kprv_i2c_dev_init(KI2CNum i2c)
     return I2C_ERROR_NULL_HANDLE;
 }
 
+/**
+ * i2c hardware cleanup and disabling
+ * @param i2c bus num to terminate
+ * @return KI2CStatus I2C_OK if success, otherwise a specific error flag
+ */
 KI2CStatus kprv_i2c_dev_terminate(KI2CNum i2c)
 {
     hal_i2c_handle * handle = i2c_handle(i2c);
@@ -135,6 +141,14 @@ KI2CStatus kprv_i2c_dev_terminate(KI2CNum i2c)
     return I2C_ERROR_NULL_HANDLE;
 }
 
+/**
+ * Write data over i2c bus as master
+ * @param i2c i2c bus to write to
+ * @param addr i2c address to write to
+ * @param ptr pointer to data buffer
+ * @param len length of data to write
+ * @return KI2CStatus I2C_OK on success, otherwise failure
+ */
 KI2CStatus kprv_i2c_master_write(KI2CNum i2c, uint16_t addr, uint8_t *ptr, int len)
 {
     hal_i2c_status ret = HAL_I2C_ERROR;
@@ -143,6 +157,14 @@ KI2CStatus kprv_i2c_master_write(KI2CNum i2c, uint16_t addr, uint8_t *ptr, int l
     return (KI2CStatus)ret;
 }
 
+/**
+ * Read data over i2c bus as master
+ * @param i2c i2c bus to read from
+ * @param addr i2c address to write to
+ * @param ptr pointer to data buffer
+ * @param len length of data to read
+ * @return KI2CStatus I2C_OK on success, otherwise failure
+ */
 KI2CStatus kprv_i2c_master_read(KI2CNum i2c, uint16_t addr, uint8_t *ptr, int len)
 {
     hal_i2c_status ret = HAL_I2C_ERROR;
@@ -152,3 +174,5 @@ KI2CStatus kprv_i2c_master_read(KI2CNum i2c, uint16_t addr, uint8_t *ptr, int le
 }
 
 #endif
+
+/* @} */

--- a/source/i2c.c
+++ b/source/i2c.c
@@ -106,7 +106,7 @@ KI2CStatus kprv_i2c_dev_init(KI2CNum i2c)
      */
     if(k_i2c->conf.role == K_SLAVE)
     {
-        return I2C_ERROR;
+        return I2C_ERROR_CONFIG;
     }
 
     hal_i2c_config config = {

--- a/source/spi.c
+++ b/source/spi.c
@@ -131,9 +131,10 @@ static inline hal_spi_first_bit spi_first_bit(SPIFirstBit firstbit)
 }
 
 /**
-  * @brief Creates and sets up specified spi bus option.
-  * @param spi Number of spi bus to setup.
-  */
+ * Setup and enable SPI bus
+ * @param spi SPI bus to initialize
+ * @return KSPIStatus SPI_OK if success, otherwise a specific error flag
+ */
 KSPIStatus kprv_spi_dev_init(KSPINum spi)
 {
     KSPI *k_spi = kprv_spi_get(spi);
@@ -169,6 +170,11 @@ KSPIStatus kprv_spi_dev_init(KSPINum spi)
     return SPI_ERROR_NULL_HANDLE;
 }
 
+/**
+ * SPI hardware cleanup and disabling
+ * @param spi bus num to terminate
+ * @return KSPIStatus SPI_OK if success, otherwise a specific error flag
+ */
 KSPIStatus kprv_spi_dev_terminate(KSPINum spi)
 {
     hal_spi_handle * handle = spi_handle(spi);
@@ -180,6 +186,13 @@ KSPIStatus kprv_spi_dev_terminate(KSPINum spi)
     return SPI_ERROR_NULL_HANDLE;
 }
 
+/**
+ * Write data over SPI bus
+ * @param spi SPI bus to write to
+ * @param buffer pointer to data buffer
+ * @param len length of data to write
+ * @return KSPIStatus SPI_OK on success, otherwise failure
+ */
 KSPIStatus kprv_spi_write(KSPINum spi, uint8_t *buffer, uint32_t len)
 {
     hal_spi_handle * handle = spi_handle(spi);
@@ -192,12 +205,27 @@ KSPIStatus kprv_spi_write(KSPINum spi, uint8_t *buffer, uint32_t len)
     return (KSPIStatus)ret;
 }
 
+/**
+ * Read data over SPI bus
+ * @param spi SPI bus to read from
+ * @param buffer pointer to data buffer
+ * @param len length of data to read
+ * @return KSPIStatus SPI_OK on success, otherwise failure
+ */
 KSPIStatus kprv_spi_read(KSPINum spi, uint8_t *buffer, uint32_t len)
 {
     hal_spi_status ret = hal_spi_master_read(spi_handle(spi), buffer, len);
     return (KSPIStatus)ret;
 }
 
+/**
+ * Write and read data over SPI bus
+ * @param spi SPI bus to write to
+ * @param txBuffer pointer to data buffer to write from
+ * @param rxBuffer pointer to data buffer to read into
+ * @param len length of data to write and read
+ * @return KSPIStatus SPI_OK on success, otherwise failure
+ */
 KSPIStatus kprv_spi_write_read(KSPINum spi, uint8_t *txBuffer, uint8_t *rxBuffer, uint32_t len)
 {
     hal_spi_handle * handle = spi_handle(spi);

--- a/source/uart.c
+++ b/source/uart.c
@@ -250,7 +250,7 @@ void hal_uart_interrupt(hal_uart_handle * handle)
 KUARTStatus k_uart_write_immediate(KUARTNum uart, char c)
 {
     hal_uart_handle *handle = uart_handle(uart);
-    if (!handle) {
+    if (handle == NULL) {
         return UART_ERROR_NULL_HANDLE;
     }
 
@@ -269,7 +269,7 @@ KUARTStatus k_uart_write_immediate(KUARTNum uart, char c)
 KUARTStatus k_uart_write_immediate_str(KUARTNum uart, uint8_t * ptr, uint8_t len)
 {
     hal_uart_handle *handle = uart_handle(uart);
-    if (!handle) {
+    if (handle == NULL) {
         return UART_ERROR_NULL_HANDLE;
     }
 

--- a/test/i2c.c
+++ b/test/i2c.c
@@ -1,0 +1,644 @@
+/*
+ * KubOS Core Flight Services
+ * Copyright (C) 2015 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the MSP430 I2C bus
+ *
+ * Wiring:
+ *  - P4.2 to SCL
+ *  - P4.1 to SDA
+ *  - 3.3V to Vin
+ *  - Gnd to Gnd
+ *
+ * Note:
+ *  Kubos-HAL doesn't currently support I2C slave mode, so all of these tests were created to be
+ *  run with the I2C bus connected to a BNO055 sensor.  Once slave mode is implemented, these tests
+ *  should be updated to keep the setup entirely contained within the MSP430 board.
+ */
+#include "unity/unity.h"
+#include "unity/k_test.h"
+#include <string.h>
+
+#include "kubos-hal/i2c.h"
+
+#include "kubos-core/modules/sensors/bno055.h"
+
+#define I2C_BUS K_I2C2
+#define BNO055_ADDRESS_A (0x28)
+#define BNO055_CHIP_ID_ADDR (0x00)
+#define BNO055_ID (0xA0)
+
+#define NUM_BNO055_OFFSET_REGISTERS (22)
+
+//Establishes configuration and initialization for the tests
+void test_i2c_setup(void)
+{
+    int ret;
+
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_7BIT,
+        .role = K_MASTER,
+        .clock_speed = 100000
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+}
+
+/**
+ * test_i2c_initNoConfig
+ *
+ * Purpose:  Test the base level i2c port initialization without giving a
+ *  configuration profile.
+ *
+ */
+
+static void test_i2c_initNoConfig(void)
+{
+    int ret;
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+
+}
+
+/**
+ * test_i2c_initGood
+ *
+ * Purpose:  Test the base level i2c port initialization
+ *
+ */
+
+static void test_i2c_initGood(void)
+{
+    int ret;
+
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_7BIT,
+        .role = K_MASTER,
+        .clock_speed = 100000
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+
+}
+
+/**
+ * test_i2c_initBad
+ *
+ * Purpose:  Test initializing a fake I2C port
+ *
+ */
+
+static void test_i2c_initBad(void)
+{
+    int ret;
+
+    ret = kprv_i2c_dev_init(K_NUM_I2CS+1);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR_NULL_HANDLE, ret, "Successfully initialized fake i2c port?");
+
+}
+
+/**
+ * test_i2c_termInit
+ *
+ * Purpose:  Test terminating a port that wasn't initialized
+ *
+ * Expectation: Nothing is returned except for a null-handle check, but the system at least shouldn't crash
+ *
+ */
+
+static void test_i2c_termInit(void)
+{
+    int ret;
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+
+    ret = kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to term I2C_BUS");
+}
+
+/**
+ * test_i2c_termNoninit
+ *
+ * Purpose:  Test terminating a port that wasn't initialized
+ *
+ * Expectation: Nothing is returned except for a null-handle check, but the system at least shouldn't crash
+ *
+ */
+
+static void test_i2c_termNoninit(void)
+{
+    int ret;
+
+    ret = kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to term I2C_BUS");
+}
+
+/**
+ * test_i2c_termBad
+ *
+ * Purpose:  Test terminating a fake I2C port
+ *
+ */
+
+static void test_i2c_termBad(void)
+{
+    int ret;
+
+    ret = kprv_i2c_dev_terminate(K_NUM_I2CS+1);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR_NULL_HANDLE, ret, "Successfully terminated fake i2c port?");
+
+}
+
+/**
+ * test_i2c_writeMasterGood
+ *
+ * Purpose:  Test writing to slave address
+ *
+ */
+
+static void test_i2c_writeMasterGood(void)
+{
+    int ret;
+    uint8_t buffer[2] = {(uint8_t)61, 0x00}; //cmd (0x3D): Set bno055 sensor to config mode (0x00)
+
+    test_i2c_setup();
+
+    //Send request for data
+    ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, (uint8_t*)buffer, 2);
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Write failed");
+}
+
+/**
+ * test_i2c_writeMasterBad
+ *
+ * Purpose:  Test writing to slave address that doesn't exist
+ *
+ */
+
+static void test_i2c_writeMasterBad(void)
+{
+    int ret;
+    uint8_t cmd = 0xE3;
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+
+    ret = kprv_i2c_master_write(I2C_BUS, 0x80, &cmd, sizeof cmd);
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR_NACK, ret, "Was expecting I2C_ERROR_NACK");
+}
+
+/**
+ * test_i2c_writeMasterOverflow
+ *
+ * Purpose:  Test writing more bytes than the write buffer contains
+ *
+ */
+
+static void test_i2c_writeMasterOverflow(void)
+{
+    int ret;
+    uint8_t buffer[2] = {(uint8_t)61, 0x00}; //cmd (0x3D): Set bno055 sensor to config mode (0x00)
+
+    test_i2c_setup();
+
+    //Send request for data
+    ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, (uint8_t*)buffer, 20);
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Write failed");
+}
+
+/**
+ * test_i2c_readMasterGoodSingle
+ *
+ * Purpose:  Test reading one byte from slave address
+ *
+ * Expectation: The write is requesting the chip ID number from the bno055 sensor.
+ *  The returned value should be 0xA0
+ *
+ */
+
+static void test_i2c_readMasterGoodSingle(void)
+{
+    int ret;
+    uint8_t id;
+    uint8_t reg = BNO055_CHIP_ID_ADDR;
+
+    test_i2c_setup();
+
+    //Send request for data
+    ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, (uint8_t*)&reg, 1);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Write failed");
+
+    vTaskDelay(5);
+
+    //Read value
+    ret = kprv_i2c_master_read(I2C_BUS, BNO055_ADDRESS_A, &id, 1);
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Read failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(BNO055_ID, id, "ID incorrect");
+
+}
+
+/**
+ * test_i2c_readMasterGoodMultiple
+ *
+ * Purpose:  Test reading multiple bytes from slave address
+ *
+ * Expectation: The write is requesting the software revision number from the bno055 sensor.
+ *  The returned value should be 0x1103
+ *
+ */
+
+static void test_i2c_readMasterGoodMultiple(void)
+{
+    int ret;
+    uint8_t sw[2];
+    uint8_t reg = 0x04;//BNO055_CHIP_ID_ADDR;
+
+    test_i2c_setup();
+
+    //Send request for data
+    ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, (uint8_t*)&reg, 1);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Write failed");
+
+    vTaskDelay(5);
+
+    //Read response
+    ret = kprv_i2c_master_read(I2C_BUS, BNO055_ADDRESS_A, sw, 2);
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Read failed");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0x11, sw[0], "ID incorrect");
+
+}
+
+/**
+ * test_i2c_readMasterBad
+ *
+ * Purpose:  Test reading from slave address that doesn't exist
+ *
+ */
+
+static void test_i2c_readMasterBad(void)
+{
+    int ret;
+    uint8_t value = 0;
+
+    test_i2c_setup();
+
+    ret = kprv_i2c_master_read(I2C_BUS, 0x80, &value, 1);
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR_NACK, ret, "Read returned unexpected value");
+}
+
+/**
+ * test_i2c_readMasterNoWrite
+ *
+ * Purpose:  Test reading from slave address without having written the register to read from
+ *
+ * Expectation: The read should return the value from either the last requested register,
+ *  or register 0 (chip ID)
+ *
+ */
+
+static void test_i2c_readMasterNoWrite(void)
+{
+    int ret;
+    uint8_t value = 0;
+
+    test_i2c_setup();
+
+    ret = kprv_i2c_master_read(I2C_BUS, BNO055_ADDRESS_A, &value, 1);
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Read returned unexpected value");
+}
+
+/**
+ * test_i2c_readMasterOverflow
+ *
+ * Purpose:  Test reading more bytes than the read buffer contains
+ *
+ * Expectation:  A flag should be thrown if the slave has nothing more to send and we're
+ *  still requesting data.
+ *
+ */
+
+static void test_i2c_readMasterOverflow(void)
+{
+    int ret;
+    char buffer[20] = {0};
+    uint8_t reg = BNO055_CHIP_ID_ADDR;
+
+    test_i2c_setup();
+
+    ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, (uint8_t*)&reg, 1);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Write failed");
+
+    vTaskDelay(5);
+
+    ret = kprv_i2c_master_read(I2C_BUS, BNO055_ADDRESS_A, buffer, 20);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR_BTF_TIMEOUT, ret, "Read returned unexpected value");
+
+}
+
+/**
+ * test_i2c_addrModeRead
+ *
+ * Purpose:  Test reading from slave address in 10-bit addressing mode (normally 7-bit)
+ *
+ * Expectation: The bno055 sensor only supports 7-bit mode, so this should fail
+ *
+ * Note:  Once slave mode is supported, a valid 10-bit test case should be created
+ */
+
+static void test_i2c_addrModeRead(void)
+{
+    int ret;
+
+    uint8_t value = 0;
+
+    //Set up i2c master port configuration
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_10BIT,
+        .role = K_MASTER,
+        .clock_speed = 100000
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+
+    ret = kprv_i2c_master_read(I2C_BUS, BNO055_ADDRESS_A, &value, 1);
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR_NACK, ret, "Read returned unexpected value");
+}
+
+/**
+ * test_i2c_addrModeWrite
+ *
+ * Purpose:  Test writing to slave address in 10-bit addressing mode (normally 7-bit)
+ *
+ * Expectation: The bno055 sensor only supports 7-bit mode, so this should fail
+ *
+ * Note:  Once slave mode is supported, a valid 10-bit test case should be created
+ */
+
+static void test_i2c_addrModeWrite(void)
+{
+    int ret;
+    uint8_t buffer[2] = {(uint8_t)61, 0x00};
+
+    //Set up i2c master port configuration
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_10BIT,
+        .role = K_MASTER,
+        .clock_speed = 100000
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+
+    ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, buffer, 2);
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR_NACK, ret, "Write returned unexpected value");
+}
+
+/**
+ * test_i2c_slave
+ *
+ * Purpose:  Test running I2C connection in slave mode
+ *
+ * Expectation: This should fail since slave mode isn't currently supported by Kubos-HAL
+ */
+
+static void test_i2c_slave(void)
+{
+    int ret;
+
+    //Set up i2c master port configuration
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_7BIT,
+        .role = K_SLAVE,
+        .clock_speed = 100000
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR, ret, "Successfully inititalized I2C_BUS?");
+}
+
+/**
+ * test_i2c_clockHigh
+ *
+ * Purpose:  Test I2C communication when the clock speed is above the max limit (SMCLK/4, 250kHz)
+ *
+ * Expectation: The speed should be lowered to the max and the test should complete successfully
+ */
+
+static void test_i2c_clockHigh(void)
+{
+    int ret;
+
+    uint8_t buffer[2] = {(uint8_t)61, 0x00};
+    uint8_t value;
+
+    //Set up i2c master port configuration
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_7BIT,
+        .role = K_MASTER,
+        .clock_speed = 500000
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, buffer, 2),
+            "Failed to write from I2C_BUS");
+
+    vTaskDelay(5);
+
+    ret = kprv_i2c_master_read(I2C_BUS, BNO055_ADDRESS_A, &value, 1);
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Read returned unexpected value");
+}
+
+/**
+ * test_i2c_clockLow
+ *
+ * Purpose:  Test I2C communication when the clock speed is at the minimum (1)
+ *
+ * Expectation: The test should complete successfully
+ */
+
+static void test_i2c_clockLow(void)
+{
+    int ret;
+
+    uint8_t buffer[2] = {(uint8_t)61, 0x00};
+    uint8_t value;
+
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_7BIT,
+        .role = K_MASTER,
+        .clock_speed = 1
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, buffer, 2),
+            "Failed to write from I2C_BUS");
+
+    vTaskDelay(5);
+
+    ret = kprv_i2c_master_read(I2C_BUS, BNO055_ADDRESS_A, &value, 1);
+
+
+    kprv_i2c_dev_terminate(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Read returned unexpected value");
+}
+
+/**
+ * test_i2c_clockZero
+ *
+ * Purpose:  Test I2C communication when the clock speed is zero
+ *
+ * Expectation: The test should pass because internally we'll change the 0 to 1 to prevent a divide-by-zero error
+ */
+
+static void test_i2c_clockZero(void)
+{
+    int ret;
+
+    uint8_t buffer[2] = {(uint8_t)61, 0x00};;
+    uint8_t value;
+
+    //Set up i2c master port configuration
+    KI2CConf conf = {
+        .addressing_mode = K_ADDRESSINGMODE_7BIT,
+        .role = K_MASTER,
+        .clock_speed = 0
+    };
+
+    KI2C *k_i2c = kprv_i2c_get(I2C_BUS);
+    memcpy(&k_i2c->conf, &conf, sizeof(KI2CConf));
+    k_i2c->bus_num = I2C_BUS;
+    k_i2c->i2c_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_i2c_dev_init(I2C_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Failed to init I2C_BUS");
+
+    ret = kprv_i2c_master_write(I2C_BUS, BNO055_ADDRESS_A, buffer, 2);
+    kprv_i2c_dev_terminate(I2C_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Write returned unexpected value");
+}
+
+K_TEST_MAIN() {
+    UNITY_BEGIN();
+
+    printf("\r\n---------------------------------\r\n");
+    printf("MSP430 Kubos-HAL I2C Tests:\r\n");
+    printf("---------------------------------\r\n");
+
+    RUN_TEST(test_i2c_initNoConfig);
+    RUN_TEST(test_i2c_initGood);
+    RUN_TEST(test_i2c_initBad);
+    RUN_TEST(test_i2c_termInit);
+    RUN_TEST(test_i2c_termNoninit);
+    RUN_TEST(test_i2c_termBad);
+    RUN_TEST(test_i2c_writeMasterGood);
+    RUN_TEST(test_i2c_writeMasterBad);
+    RUN_TEST(test_i2c_writeMasterOverflow);
+    RUN_TEST(test_i2c_readMasterBad);
+    RUN_TEST(test_i2c_readMasterGoodSingle);
+    RUN_TEST(test_i2c_readMasterGoodMultiple);
+    RUN_TEST(test_i2c_readMasterNoWrite);
+    RUN_TEST(test_i2c_readMasterOverflow);
+    RUN_TEST(test_i2c_addrModeWrite);
+    RUN_TEST(test_i2c_addrModeRead);
+    RUN_TEST(test_i2c_slave);
+    RUN_TEST(test_i2c_clockHigh);
+    RUN_TEST(test_i2c_clockLow);
+    RUN_TEST(test_i2c_clockZero);
+
+    return UNITY_END();
+}
+
+int main(void) {
+
+    /* Stop the watchdog. */
+    WDTCTL = WDTPW + WDTHOLD;
+
+    __enable_interrupt();
+
+    P2OUT = BIT1;
+
+
+    K_TEST_RUN_MAIN();
+
+}

--- a/test/i2c.c
+++ b/test/i2c.c
@@ -1,6 +1,6 @@
 /*
  * KubOS Core Flight Services
- * Copyright (C) 2015 Kubos Corporation
+ * Copyright (C) 2016 Kubos Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,9 +129,7 @@ static void test_i2c_initBad(void)
 /**
  * test_i2c_termInit
  *
- * Purpose:  Test terminating a port that wasn't initialized
- *
- * Expectation: Nothing is returned except for a null-handle check, but the system at least shouldn't crash
+ * Purpose:  Test terminating a port that was successfully initialized
  *
  */
 
@@ -477,7 +475,7 @@ static void test_i2c_slave(void)
     k_i2c->i2c_lock = xSemaphoreCreateMutex();
 
     ret = kprv_i2c_dev_init(I2C_BUS);
-    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR, ret, "Successfully inititalized I2C_BUS?");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_ERROR_CONFIG, ret, "Successfully inititalized I2C_BUS?");
 }
 
 /**

--- a/test/i2c.c
+++ b/test/i2c.c
@@ -636,9 +636,6 @@ int main(void) {
 
     __enable_interrupt();
 
-    P2OUT = BIT1;
-
-
     K_TEST_RUN_MAIN();
 
 }

--- a/test/i2c.c
+++ b/test/i2c.c
@@ -596,6 +596,10 @@ static void test_i2c_clockZero(void)
     TEST_ASSERT_EQUAL_INT_MESSAGE(I2C_OK, ret, "Write returned unexpected value");
 }
 
+/*
+ * Note:  Added vTaskDelay between each test because without them the MSP430 will sometimes lock up between
+ * passing one test and starting the next.
+ */
 K_TEST_MAIN() {
     UNITY_BEGIN();
 
@@ -604,24 +608,43 @@ K_TEST_MAIN() {
     printf("---------------------------------\r\n");
 
     RUN_TEST(test_i2c_initNoConfig);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_initGood);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_initBad);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_termInit);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_termNoninit);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_termBad);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_writeMasterGood);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_writeMasterBad);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_writeMasterOverflow);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_readMasterBad);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_readMasterGoodSingle);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_readMasterGoodMultiple);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_readMasterNoWrite);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_readMasterOverflow);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_addrModeWrite);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_addrModeRead);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_slave);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_clockHigh);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_clockLow);
+    vTaskDelay(10);
     RUN_TEST(test_i2c_clockZero);
 
     return UNITY_END();

--- a/test/spi.c
+++ b/test/spi.c
@@ -1,0 +1,913 @@
+/*
+ * KubOS Core Flight Services
+ * Copyright (C) 2015 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Unit tests for the MSP430 spi bus
+ *
+ * Wiring:
+ *  - P3.0 to SDI
+ *  - P3.1 to SDO
+ *  - P3.2 to SCK
+ *  - CS (P2.7) to CS
+ *
+ * Note:
+ *  Kubos-HAL doesn't currently support SPI slave mode, so all of these tests were created to be
+ *  run with the SPI bus connected to a BME280 sensor.  Once slave mode is implemented, these tests
+ *  should be updated to keep the setup entirely contained within the MSP430 board.
+ */
+#include "unity/unity.h"
+#include "unity/k_test.h"
+#include <string.h>
+
+#include "kubos-hal/spi.h"
+#include "kubos-hal/gpio.h"
+
+#define CS P27
+#define SPI_BUS K_SPI1
+
+/*
+ * soft_reset
+ *
+ * This function resets the power of the BME280 sensor.  This is important particularly for tests
+ * where the configuration changes.  The sensor doesn't like it when we just change the clock rate,
+ * for instance.
+ */
+void soft_reset(void)
+{
+    int ret = 0;
+    uint8_t resetReg = 0xE0 & ~0x80; //Reset register, high bit low for write request
+    uint8_t resetValue = 0xB6;       //Soft reset
+
+    vTaskDelay(5);
+
+    k_gpio_write(CS, 0);
+    ret = k_spi_write(SPI_BUS, &resetReg, 1);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write reset register to SPI_BUS");
+    ret = k_spi_write(SPI_BUS, &resetValue, 1);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write reset value to SPI_BUS");
+
+    k_gpio_write(CS, 1);
+
+    vTaskDelay(5);
+}
+
+void test_spi_setup(void)
+{
+    int ret = 0;
+
+    //Initialize the chip select pin
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    //Set up the configuration parameters
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 10000;
+    k_spi->config.clock_phase = K_SPI_CPHA_1EDGE;
+    k_spi->config.clock_polarity = K_SPI_CPOL_LOW;
+    k_spi->config.first_bit = K_SPI_FIRSTBIT_MSB;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    //Initialize the bus
+    ret = kprv_spi_dev_init(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to init SPI_BUS");
+
+    //Soft-reset the BME280 sensor
+    soft_reset();
+
+}
+
+/*
+ * test_spi_initGood
+ *
+ * Purpose:  Test the base level spi port initialization
+ *
+ */
+
+static void test_spi_initGood(void)
+{
+    int ret;
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 10000;
+    k_spi->config.clock_phase = K_SPI_CPHA_1EDGE;
+    k_spi->config.clock_polarity = K_SPI_CPOL_LOW;
+    k_spi->config.first_bit = K_SPI_FIRSTBIT_MSB;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to init SPI_BUS");
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+}
+
+/*
+ * test_spi_initBad
+ *
+ * Purpose:  Try initializing a non-existent spi port
+ *
+ */
+
+static void test_spi_initBad(void)
+{
+    int ret;
+
+    ret = kprv_spi_dev_init(K_NUM_SPI+1);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_ERROR_NULL_HANDLE, ret, "Successfully initialized fake spi port?");
+}
+
+/*
+ * test_spi_termInit
+ *
+ * Purpose:  Test terminating a properly initialized spi port
+ *
+ */
+
+static void test_spi_termInit(void)
+{
+    int ret;
+
+    test_spi_setup();
+
+    ret = kprv_spi_dev_terminate(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to terminate SPI_BUS");
+}
+
+/*
+ * test_spi_termNoninit
+ *
+ * Purpose:  Test terminating a spi port that wasn't initialized
+ *
+ * Expectation: Should return a successful value
+ *
+ */
+
+static void test_spi_termNoninit(void)
+{
+    int ret;
+
+    ret = kprv_spi_dev_terminate(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to terminate SPI_BUS");
+}
+
+/*
+ * test_spi_termNoninit
+ *
+ * Purpose:  Test terminating a spi port that doesn't exist
+ *
+ */
+
+static void test_spi_termBad(void)
+{
+    int ret;
+
+    ret = kprv_spi_dev_terminate(K_NUM_SPI+1);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_ERROR_NULL_HANDLE, ret, "Successfully terminated fake spi port?");
+}
+
+/*
+ * test_spi_writeMaster
+ *
+ * Purpose:  Test writing from a properly initialized spi port
+ *
+ */
+
+static void test_spi_writeMaster(void)
+{
+    int ret;
+    uint8_t chipReg = 0xD0; //Chip ID register
+    chipReg |= 0x80; //Turn on high bit for read request
+
+    test_spi_setup();
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+
+    k_gpio_write(CS, 1);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+}
+
+/*
+ * test_spi_writeMasterNoCS
+ *
+ * Purpose:  Test writing from a properly initialized spi port without driving chip select
+ *  low to select a slave device
+ *
+ * Expectation: Should complete successfully
+ *
+ */
+
+static void test_spi_writeMasterNoCS(void)
+{
+    int ret;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    test_spi_setup();
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+}
+
+/*
+ * test_spi_writeMasterNoninit
+ *
+ * Purpose:  Test writing from a spi port without initializing it first
+ *
+ */
+
+static void test_spi_writeMasterNoninit(void)
+{
+    int ret;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    vTaskDelay(20);
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+
+    k_gpio_write(CS, 1);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_ERROR_BUSY, ret, "Unexpected value returned from write");
+}
+
+/*
+ * test_spi_writeMasterOverflow
+ *
+ * Purpose:  Test writing more bytes than the write buffer contains
+ *
+ */
+
+static void test_spi_writeMasterOverflow(void)
+{
+    int ret;
+    uint8_t chipReg = 0xD0; //Chip ID register
+    chipReg |= 0x80; //Turn on high bit for read request
+
+    test_spi_setup();
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, 100);
+
+    k_gpio_write(CS, 1);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+}
+
+/*
+ * test_spi_readMaster
+ *
+ * Purpose:  Test reading from a properly initialized spi port
+ *
+ * Expectation:  This test currently requests the chip ID number from the BME280 sensor. The returned
+ *  value should be 0x60.
+ *
+ */
+
+static void test_spi_readMaster(void)
+{
+    int ret;
+    uint8_t id;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    test_spi_setup();
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+
+    ret = kprv_spi_read(SPI_BUS, &id, sizeof id);
+
+    k_gpio_write(CS, 1);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to read from SPI_BUS");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0x60, id, "ID incorrect");
+}
+
+/*
+ * test_spi_readMasterNoCS
+ *
+ * Purpose:  Test reading from a properly initialized spi port without driving chip select
+ *  low to select a slave device
+ *
+ * Expectation: TODO
+ *
+ */
+
+static void test_spi_readMasterNoCS(void)
+{
+    int ret;
+    uint8_t id;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    test_spi_setup();
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+
+    ret = kprv_spi_read(SPI_BUS, &id, sizeof id);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to read from SPI_BUS");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0xFF, id, "Read request returned unexpected value");
+}
+
+/*
+ * test_spi_readMasterNoWrite
+ *
+ * Purpose:  Test reading from a properly initialized spi port without writing which register to
+ *  read from first
+ *
+ * Expectation: The read call should complete, but the slave should only give a value of 0xFF
+ *  since it won't know what was supposed to be sent
+ *
+ */
+
+static void test_spi_readMasterNoWrite(void)
+{
+    int ret;
+    uint8_t id = 0;
+
+    test_spi_setup();
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_read(SPI_BUS, &id, sizeof id);
+
+    k_gpio_write(CS, 1);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to read from SPI_BUS");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0xFF, id, "Read request returned unexpected value");
+}
+
+
+/*
+ * test_spi_readMasterOverflow
+ *
+ * Purpose:  Test reading more bytes than the read buffer contains
+ *
+ */
+
+static void test_spi_readMasterOverflow(void)
+{
+    int ret;
+    char buffer[100] = {0};
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    test_spi_setup();
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+
+    ret = kprv_spi_read(SPI_BUS, buffer, 100);
+
+    k_gpio_write(CS, 1);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to read from SPI_BUS");
+}
+
+/*
+ * test_spi_writeReadMaster
+ *
+ * Purpose:  Test the write_read function from a properly initialized spi port
+ *
+ * Note:  This test is not currently being called because it doesn't currently work.
+ * The BME280 sensor doesn't support writeRead calls and attempting to make a call will
+ * return zero and appear successful, but will cause all subsequent tests to hang.
+ * TODO:  Once something capable of writeRead calls is available (like the MSP430 in slave
+ * mode), fully implement this test.
+ */
+
+static void test_spi_writeReadMaster(void)
+{
+    int ret;
+    uint8_t id = 0;
+    uint8_t chipReg = 0xD0; //Chip ID register
+    chipReg |= 0x80; //Turn on high bit for read request
+
+    test_spi_setup();
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write_read(SPI_BUS, &chipReg, &id, sizeof chipReg);
+
+    k_gpio_write(CS, 1);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Write/read failed from SPI_BUS");
+}
+
+/*
+ * test_spi_slave
+ *
+ * Purpose:  Test running spi connection in slave mode
+ *
+ * Expectation: This should fail since slave mode isn't currently supported by Kubos-HAL
+ */
+
+static void test_spi_slave(void)
+{
+    int ret = 0;
+
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_SLAVE;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 10000;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_ERROR_CONFIG, ret, "Failed to init SPI_BUS");
+}
+
+/*
+ * test_spi_bidiMode
+ *
+ * Purpose:  Test spi communication using the bidirectional mode (communicates only over MOSI line)
+ *
+ * Expectation:  Should return configuration error.  The MSP430 doesn't support bidirectional mode.
+ *
+ */
+
+static void test_spi_bidiMode(void)
+{
+    int ret = 0;
+    uint8_t id = 0;
+
+    //Setup
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_1LINE;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 10000;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_ERROR_CONFIG, ret, "Failed to init SPI_BUS");
+}
+
+/*
+ * test_spi_rxOnly
+ *
+ * Purpose:  Test spi communication in RX-only mode
+ *
+ * Expectation:  Initialization should be successful, but writing should fail
+ *
+ */
+
+static void test_spi_rxOnly(void)
+{
+    int ret;
+    uint8_t id;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    //Setup
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES_RXONLY;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 10000;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to init SPI_BUS");
+    //End of setup
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, 1);
+
+    k_gpio_write(CS, 1);
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_ERROR, ret, "Failed to write from SPI_BUS");
+
+}
+
+/*
+ * test_spi_clock
+ *
+ * Purpose:  Test spi communication with non-default clock phase and clock polarity
+ *
+ * Note:  BME280 sensor only supports 1edge/low and 2edge/high for clock phase/polarity.
+ *   Expand to other two cases once slave mode has been implemented
+ */
+
+static void test_spi_clock(void)
+{
+    int ret = 0;
+    uint8_t id;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    //Setup
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 10000;
+    k_spi->config.clock_phase = K_SPI_CPHA_2EDGE;
+    k_spi->config.clock_polarity = K_SPI_CPOL_HIGH;
+    k_spi->config.first_bit = K_SPI_FIRSTBIT_MSB;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to init SPI_BUS");
+
+    soft_reset();
+    //End of setup
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+
+    ret = kprv_spi_read(SPI_BUS, &id, sizeof id);
+
+    k_gpio_write(CS, 1);
+
+    soft_reset();
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to read from SPI_BUS");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0x60, id, "ID incorrect");
+}
+
+/*
+ * test_spi_LSBFirst
+ *
+ * Purpose:  Test spi communication sending the LSB first
+ *
+ */
+
+static void test_spi_LSBFirst(void)
+{
+    int ret = 0;
+    uint8_t id;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    //Setup
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 10000;
+    k_spi->config.clock_phase = K_SPI_CPHA_1EDGE;
+    k_spi->config.clock_polarity = K_SPI_CPOL_LOW;
+    k_spi->config.first_bit = K_SPI_FIRSTBIT_LSB;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to init SPI_BUS");
+
+    soft_reset();
+    //End of setup
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+
+    ret = kprv_spi_read(SPI_BUS, &id, sizeof id);
+
+    k_gpio_write(CS, 1);
+
+    soft_reset();
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to read from SPI_BUS");
+}
+
+/*
+ * test_spi_16bitMode
+ *
+ * Purpose:  Test spi communication using 16-bit mode
+ *
+ * Expectation: Should return configuration error.  The MSP430 doesn't support 16-bit mode.
+ *
+ */
+
+static void test_spi_16bitMode(void)
+{
+    int ret = 0;
+    uint8_t id;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    //Setup
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES;
+    k_spi->config.data_size = K_SPI_DATASIZE_16BIT;
+    k_spi->config.speed = 10000;
+    k_spi->config.clock_phase = K_SPI_CPHA_2EDGE;
+    k_spi->config.clock_polarity = K_SPI_CPOL_HIGH;
+    k_spi->config.first_bit = K_SPI_FIRSTBIT_MSB;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_ERROR_CONFIG, ret, "Initialization returned unexpected value");
+}
+
+/*
+ * test_spi_clockSpeedHigh
+ *
+ * Purpose:  Test spi communication using the highest clock speed possible
+ *
+ * Note: This is currently limited to the BME280's max speed, 10MHz. The MSP430's max speed is 1MHz
+ *  (set by SMCLK), so the actual clock speed should be forced to 1MHz.
+ */
+static void test_spi_clockSpeedHigh(void)
+{
+    int ret = 0;
+    uint8_t id;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    //Setup
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 10000000; //10MHz, max frequency for BME280 sensor
+    k_spi->config.clock_phase = K_SPI_CPHA_1EDGE;
+    k_spi->config.clock_polarity = K_SPI_CPOL_LOW;
+    k_spi->config.first_bit = K_SPI_FIRSTBIT_MSB;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to init SPI_BUS");
+
+    soft_reset();
+    //End of setup
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+
+    ret = kprv_spi_read(SPI_BUS, &id, sizeof id);
+
+    k_gpio_write(CS, 1);
+
+    soft_reset();
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to read from SPI_BUS");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0x60, id, "ID incorrect");
+}
+
+/*
+ * test_spi_clockSpeedLow
+ *
+ * Purpose:  Test spi communication using the lowest clock speed possible
+ *
+ * Note: This will try to set the speed to 1Hz, but the prescaler calculation will
+ *   actually end up setting it to SMCLK/256 since we cannot directly set the SPI clock
+ *   speed.
+ */
+
+static void test_spi_clockSpeedLow(void)
+{
+    int ret = 0;
+    uint8_t id;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    //Setup
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 1; //1Hz
+    k_spi->config.clock_phase = K_SPI_CPHA_1EDGE;
+    k_spi->config.clock_polarity = K_SPI_CPOL_LOW;
+    k_spi->config.first_bit = K_SPI_FIRSTBIT_MSB;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to init SPI_BUS");
+
+    soft_reset();
+    //End of setup
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+
+    ret = kprv_spi_read(SPI_BUS, &id, sizeof id);
+
+    k_gpio_write(CS, 1);
+
+    soft_reset();
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to read from SPI_BUS");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0x60, id, "ID incorrect");
+}
+
+/*
+ * test_spi_clockSpeedZero
+ *
+ * Purpose:  Test spi communication a clock speed of zero
+ *
+ * Expectation: The test should pass because internally we'll change the 0 to 1 to prevent a divide-by-zero error
+ */
+
+static void test_spi_clockSpeedZero(void)
+{
+    int ret = 0;
+    uint8_t id;
+    uint8_t chipReg = 0xD0;
+    chipReg |= 0x80;
+
+    //Setup
+    k_gpio_init(CS, K_GPIO_OUTPUT, K_GPIO_PULL_UP);
+    k_gpio_write(CS, 1);
+
+    KSPI * k_spi = kprv_spi_get(SPI_BUS);
+    k_spi->config.role = K_SPI_MASTER;
+    k_spi->config.direction = K_SPI_DIRECTION_2LINES;
+    k_spi->config.data_size = K_SPI_DATASIZE_8BIT;
+    k_spi->config.speed = 0;
+    k_spi->config.clock_phase = K_SPI_CPHA_1EDGE;
+    k_spi->config.clock_polarity = K_SPI_CPOL_LOW;
+    k_spi->config.first_bit = K_SPI_FIRSTBIT_MSB;
+
+    k_spi->bus_num = SPI_BUS;
+    k_spi->spi_lock = xSemaphoreCreateMutex();
+
+    ret = kprv_spi_dev_init(SPI_BUS);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to init SPI_BUS");
+
+    soft_reset();
+    //End of setup
+
+    k_gpio_write(CS, 0);
+
+    ret = kprv_spi_write(SPI_BUS, &chipReg, sizeof chipReg);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to write from SPI_BUS");
+
+    ret = kprv_spi_read(SPI_BUS, &id, sizeof id);
+
+    k_gpio_write(CS, 1);
+
+    soft_reset();
+
+    kprv_spi_dev_terminate(SPI_BUS);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(SPI_OK, ret, "Failed to read from SPI_BUS");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0x60, id, "ID incorrect");
+}
+
+K_TEST_MAIN() {
+    UNITY_BEGIN();
+
+    printf("\r\n---------------------------------\r\n");
+    printf("MSP430 Kubos-HAL SPI Tests:\r\n");
+    printf("---------------------------------\r\n");
+
+    RUN_TEST(test_spi_initGood);
+    RUN_TEST(test_spi_initBad);
+    RUN_TEST(test_spi_termInit);
+    RUN_TEST(test_spi_termNoninit);
+    RUN_TEST(test_spi_termBad);
+    RUN_TEST(test_spi_writeMaster);
+    RUN_TEST(test_spi_writeMasterNoCS);
+    RUN_TEST(test_spi_writeMasterNoninit);
+    RUN_TEST(test_spi_writeMasterOverflow);
+    RUN_TEST(test_spi_readMaster);
+    RUN_TEST(test_spi_readMasterNoCS);
+    RUN_TEST(test_spi_readMasterNoWrite);
+    RUN_TEST(test_spi_readMasterOverflow);
+    RUN_TEST(test_spi_slave);
+    RUN_TEST(test_spi_bidiMode);
+    RUN_TEST(test_spi_rxOnly);
+    RUN_TEST(test_spi_clock);
+    RUN_TEST(test_spi_LSBFirst);
+    RUN_TEST(test_spi_16bitMode);
+    RUN_TEST(test_spi_clockSpeedHigh);
+    RUN_TEST(test_spi_clockSpeedLow);
+    RUN_TEST(test_spi_clockSpeedZero);
+
+    return UNITY_END();
+}
+
+int main(void) {
+
+    /* Stop the watchdog. */
+    WDTCTL = WDTPW + WDTHOLD;
+
+    __enable_interrupt();
+
+    K_TEST_RUN_MAIN();
+
+}

--- a/test/spi.c
+++ b/test/spi.c
@@ -1,6 +1,6 @@
 /*
  * KubOS Core Flight Services
- * Copyright (C) 2015 Kubos Corporation
+ * Copyright (C) 2016 Kubos Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,7 +175,7 @@ static void test_spi_termNoninit(void)
 }
 
 /*
- * test_spi_termNoninit
+ * test_spi_termBad
  *
  * Purpose:  Test terminating a spi port that doesn't exist
  *
@@ -322,6 +322,8 @@ static void test_spi_readMaster(void)
     ret = kprv_spi_read(SPI_BUS, &id, sizeof id);
 
     k_gpio_write(CS, 1);
+
+    vTaskDelay(50);
 
     kprv_spi_dev_terminate(SPI_BUS);
 

--- a/test/uart.c
+++ b/test/uart.c
@@ -255,7 +255,6 @@ static void test_uart_readOverflow(void)
     char * testString = "test string 1";
     char buffer[100] = {0};
     int len = strlen(testString);
-    int returnLenWrite = 0;
     int returnLenRead = 0;
 
     conf = (KUARTConf) {
@@ -476,7 +475,6 @@ static void test_uart_overrun(void)
     KUART *k_uart;
     char * testString = "test string 1";
     int len = strlen(testString);
-    int returnLenWrite = 0;
     int returnLenRead = 0;
 
     conf = (KUARTConf) {

--- a/test/uart.c
+++ b/test/uart.c
@@ -275,7 +275,6 @@ static void test_uart_readOverflow(void)
 
     k_uart_terminate(uart_bus);
 
-    TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenWrite, "Failed to write");
     TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenRead, "Failed to read");
 }
 

--- a/test/uart.c
+++ b/test/uart.c
@@ -1,6 +1,6 @@
 /*
  * KubOS Core Flight Services
- * Copyright (C) 2015 Kubos Corporation
+ * Copyright (C) 2016 Kubos Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uart.c
+++ b/test/uart.c
@@ -1,0 +1,540 @@
+/*
+ * KubOS Core Flight Services
+ * Copyright (C) 2015 Kubos Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the MSP430 UARTs
+ *
+ * Wiring:
+ *  - P3.4 -> MTK3339 Rx
+ *  - P3.3 -> MTK3339 Tx
+ *
+ * Note:
+ *  The MSP430 only has two available UART ports.  In order to reserve one for console output, these tests were
+ *  created to be run against a MTK3339 GPS sensor breakout board.
+ *
+ */
+#include "unity/unity.h"
+#include "unity/k_test.h"
+#include <string.h>
+
+#include "kubos-hal-msp430f5529/uart.h"
+#include "msp430f5529-hal/uart.h"
+
+#define uart_bus K_UART1
+
+//UART Tests
+
+/**
+ * test_uart_initGood
+ *
+ * Purpose:  Test the base level uart port initialization
+ *
+ */
+
+static void test_uart_initGood(void)
+{
+    int ret;
+
+    ret = kprv_uart_dev_init(uart_bus);
+
+    k_uart_terminate(uart_bus);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, ret, "Failed to init UART1");
+}
+
+/**
+ * test_uart_initBad
+ *
+ * Purpose:  Test UART port number validation during initialization
+ *
+ */
+static void test_uart_initBad(void)
+{
+    int ret;
+
+    ret = kprv_uart_dev_init(K_NUM_UARTS+1);
+
+    TEST_ASSERT_EQUAL_INT(UART_ERROR_NULL_HANDLE, ret);
+}
+
+/**
+ * test_uart_write
+ *
+ * Purpose:  Test writing out of the UART port
+ *
+ */
+
+static void test_uart_write(void)
+{
+    KUARTConf conf;
+    char *testString = "$PMTK000*32\r\n"; //MTK3339 test command
+    int len = strlen(testString);
+    int returnLen = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    k_uart_init(uart_bus, &conf);
+    returnLen = k_uart_write(uart_bus, testString, len);
+
+    k_uart_terminate(uart_bus);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLen, "Failed to write");
+}
+
+/**
+ * test_uart_writeOverflow
+ *
+ * Purpose:  Test writing more bytes than the write buffer contains
+ *
+ */
+
+static void test_uart_writeOverflow(void)
+{
+    KUARTConf conf;
+    char * testString = "$PMTK000*32\r\n";
+    int len = strlen(testString);
+    int returnLen = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    k_uart_init(uart_bus, &conf);
+
+    returnLen = k_uart_write(uart_bus, testString, 20);
+
+    k_uart_terminate(uart_bus);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(20, returnLen, "Failed to write");
+
+
+}
+
+
+/**
+ * test_uart_writeImmediate
+ *
+ * Purpose:  Test the write_immediate function, which sends a single character directly out the UART port,
+ *  bypassing the send queue.
+ *
+ */
+
+static void test_uart_writeImmediate(void)
+{
+    KUARTConf conf;
+    int ret = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    TEST_ASSERT_FALSE(k_uart_init(uart_bus, &conf));
+
+    ret = k_uart_write_immediate(uart_bus,'a');
+
+    k_uart_terminate(uart_bus);
+    TEST_ASSERT_EQUAL_INT(UART_OK, ret);
+}
+
+/**
+ * test_uart_writeImmediateStr
+ *
+ * Purpose:  Test the write_immediate_str function, which sends a string directly out the UART port,
+ *  bypassing the send queue.
+ *
+ */
+
+static void test_uart_writeImmediateStr(void)
+{
+    KUARTConf conf;
+    char *testString = "$PMTK000*32\r\n"; //Empty test command
+    int ret = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    TEST_ASSERT_FALSE(k_uart_init(uart_bus, &conf));
+
+    ret = k_uart_write_immediate_str(uart_bus, testString, strlen(testString));
+
+    k_uart_terminate(uart_bus);
+    TEST_ASSERT_EQUAL_INT(UART_OK, ret);
+}
+
+/**
+ * test_uart_read
+ *
+ * Purpose:  Test reading from the UART port
+ *
+ * Note:  Ideally we'd check the characters that were read to make sure they're what we were
+ *   expecting.  However, the MTK3339 is constantly sending data, so we can't be sure what data
+ *   exactly we're reading in.
+ *
+ */
+
+static void test_uart_read(void)
+{
+    KUARTConf conf;
+    KUART *k_uart;
+    char recvString[10] = {0};
+    int returnLenRead = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    TEST_ASSERT_FALSE(k_uart_init(uart_bus, &conf));
+
+    vTaskDelay(1100); //wait for there to be things in the buffer
+
+    returnLenRead = k_uart_read(uart_bus, recvString, sizeof recvString);
+
+    k_uart_terminate(uart_bus);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(sizeof recvString, returnLenRead, "Failed to read");
+}
+
+/**
+ * test_uart_readOverflow
+ *
+ * Purpose:  Test reading more bytes than the read buffer contains
+ *
+ * Expectation: The read call should only read as many bytes as are available and then return
+ *  which will be the length of testString.
+ *
+ * TODO:  The MTK3339 GPS sensor continually sends data, so the receive buffer will always be full.
+ *   Start using this test case if there's another device that can be used to test with that doesn't
+ *   always send data.
+ *
+ */
+
+static void test_uart_readOverflow(void)
+{
+    KUARTConf conf;
+    KUART *k_uart;
+    char * testString = "test string 1";
+    char buffer[100] = {0};
+    int len = strlen(testString);
+    int returnLenWrite = 0;
+    int returnLenRead = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    TEST_ASSERT_FALSE(k_uart_init(uart_bus, &conf));
+
+    vTaskDelay(50);
+
+    returnLenRead = k_uart_read(uart_bus, buffer, 100);
+
+    k_uart_terminate(uart_bus);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenWrite, "Failed to write");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(len, returnLenRead, "Failed to read");
+}
+
+
+/**
+ * test_uart_wordLen7
+ *
+ * Purpose:  Test UART communication when the word length configurations are mismatched
+ *
+ * Expectation: The message should be discarded and uart_read should return 0 bytes
+ *
+ */
+
+static void test_uart_wordLen7(void)
+{
+    KUARTConf conf;
+    KUART *k_uart;
+    char * testString = "test string 1";
+    int len = strlen(testString);
+    int returnLenRead = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_7BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    TEST_ASSERT_FALSE(k_uart_init(uart_bus, &conf));
+
+    vTaskDelay(1100);
+
+    returnLenRead = k_uart_read(uart_bus, testString, len);
+
+    k_uart_terminate(uart_bus);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, returnLenRead, "Should have received 0 bytes");
+}
+
+/**
+ * test_uart_wordLen9
+ *
+ * Purpose:  Test UART communication with an unsupported word length
+ *
+ * Expectation: The initialization should fail
+ *
+ *TODO: FIX ME
+ */
+
+static void test_uart_wordLen9(void)
+{
+    int ret = 0;
+    KUARTConf conf;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_9BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    ret = k_uart_init(uart_bus, &conf);
+    TEST_ASSERT_EQUAL_INT(UART_ERROR_CONFIG, ret);
+}
+
+/**
+ * test_uart_parity
+ *
+ * Purpose:  Test UART communication when the parity bit configurations are mismatched
+ *
+ * Expectation: The message should be discarded and uart_read should return 0 bytes
+ *
+ * Note:  The MTK3339 is configured with parity none.  As a result, we'll occasionally
+ *   receive messages that look like they have the correct parity.  For this test, we're
+ *   looking to reject at least some of the bytes we're trying to read.  If this test is
+ *   ever updated to have an endpoint with a parity other than none, the pass condition
+ *   can be updated to be exactly zero bytes read.
+ *
+ */
+static void test_uart_parity(void)
+{
+    KUARTConf conf;
+    KUART *k_uart;
+    char * testString = "test string 123456789012345678";
+    int len = strlen(testString);
+    int returnLenRead = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_EVEN,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    TEST_ASSERT_FALSE(k_uart_init(uart_bus, &conf));
+
+    vTaskDelay(1100);
+
+    returnLenRead = k_uart_read(uart_bus, testString, len);
+
+    k_uart_terminate(uart_bus);
+    TEST_ASSERT_INT_WITHIN_MESSAGE((len-1),0, returnLenRead, "Should have received < 30 bytes");
+}
+
+/**
+ * test_uart_stopbits
+ *
+ * Purpose:  Test UART communication when the parity bit configurations are mismatched
+ *
+ * Expectation: The message should be discarded and uart_read should return 0 bytes
+ *
+ * Note:  Detecting stop bits isn't perfect.  Sometimes the next bit just happens to look correct.
+ *   As a result, we're looking to just receive fewer bytes than we requested.
+ *
+ */
+static void test_uart_stopbits(void)
+{
+    KUARTConf conf;
+    KUART *k_uart;
+    char * testString = "test string 123456789012345678";
+    int len = strlen(testString);
+    int returnLenRead = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_2,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    TEST_ASSERT_FALSE(k_uart_init(uart_bus, &conf));
+
+    vTaskDelay(1100);
+
+    returnLenRead = k_uart_read(uart_bus, testString, len);
+
+    k_uart_terminate(uart_bus);
+    TEST_ASSERT_INT_WITHIN_MESSAGE((len-1),0, returnLenRead, "Should have received < 30 bytes");
+}
+
+/**
+ * test_uart_baudRate
+ *
+ * Purpose:  Test UART communication when the baud rate configurations are mismatched
+ *
+ * Expectation: The message should be discarded and uart_read should return 0 bytes
+ *
+ */
+
+static void test_uart_baudRate(void)
+{
+    KUARTConf conf;
+    KUART *k_uart;
+    char * testString = "test string 123456789012345678";
+    int len = strlen(testString);
+    int returnLenRead = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 115200,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    TEST_ASSERT_FALSE(k_uart_init(uart_bus, &conf));
+
+    vTaskDelay(1000);
+
+    returnLenRead = k_uart_read(uart_bus, testString, len);
+
+    k_uart_terminate(uart_bus);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, returnLenRead, "Should have received 0 bytes");
+}
+
+/**
+ * test_uart_overrun
+ *
+ * Purpose:  Test UART receive processing when a character is received before the previous character has
+ *  been processed.
+ *
+ * Expectation: The overrun characters should be discarded and uart_read should return 0 bytes
+ *
+ */
+
+static void test_uart_overrun(void)
+{
+    hal_uart_handle *handle = uart_handle(uart_bus);
+
+    KUARTConf conf;
+    KUART *k_uart;
+    char * testString = "test string 1";
+    int len = strlen(testString);
+    int returnLenWrite = 0;
+    int returnLenRead = 0;
+
+    conf = (KUARTConf) {
+        .baud_rate = 9600,
+        .word_len = K_WORD_LEN_8BIT,
+        .stop_bits = K_STOP_BITS_1,
+        .parity = K_PARITY_NONE,
+        .rx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_RXQUEUELEN,
+        .tx_queue_len = YOTTA_CFG_HARDWARE_UART_DEFAULTS_TXQUEUELEN,
+    };
+
+    TEST_ASSERT_FALSE(k_uart_init(uart_bus, &conf));
+
+    handle->reg->interruptEnable &= ~UCRXIE; //Disable receive interrupt
+
+    vTaskDelay(1000); //Make sure we're trying to receive something
+
+    handle->reg->interruptEnable |= UCRXIE; //Enable receive interrupt
+
+    returnLenRead = k_uart_read(uart_bus, testString, len);
+
+    k_uart_terminate(uart_bus);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, returnLenRead, "Should have received 0 bytes");
+}
+
+
+K_TEST_MAIN() {
+    UNITY_BEGIN();
+
+    printf("\r\n---------------------------------\r\n");
+    printf("MSP430 Kubos-HAL Uart Tests:\r\n");
+    printf("---------------------------------\r\n");
+
+    RUN_TEST(test_uart_initGood);
+    RUN_TEST(test_uart_initBad);
+    RUN_TEST(test_uart_write);
+    RUN_TEST(test_uart_writeOverflow);
+    RUN_TEST(test_uart_writeImmediate);
+    RUN_TEST(test_uart_writeImmediateStr);
+    RUN_TEST(test_uart_read);
+    RUN_TEST(test_uart_wordLen7);
+    RUN_TEST(test_uart_wordLen9);
+    RUN_TEST(test_uart_parity);
+    RUN_TEST(test_uart_stopbits);
+    RUN_TEST(test_uart_baudRate);
+    RUN_TEST(test_uart_overrun);
+
+    return UNITY_END();
+}
+
+int main(void) {
+
+    /* Stop the watchdog. */
+    WDTCTL = WDTPW + WDTHOLD;
+
+    __enable_interrupt();
+
+    K_TEST_RUN_MAIN();
+
+}

--- a/test/uart.c
+++ b/test/uart.c
@@ -500,7 +500,10 @@ static void test_uart_overrun(void)
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, returnLenRead, "Should have received 0 bytes");
 }
 
-
+/*
+ * Note:  Added vTaskDelay between each test because without them the MSP430 will sometimes lock up between
+ * passing one test and starting the next.
+ */
 K_TEST_MAIN() {
     UNITY_BEGIN();
 
@@ -509,17 +512,29 @@ K_TEST_MAIN() {
     printf("---------------------------------\r\n");
 
     RUN_TEST(test_uart_initGood);
+    vTaskDelay(10);
     RUN_TEST(test_uart_initBad);
+    vTaskDelay(10);
     RUN_TEST(test_uart_write);
+    vTaskDelay(10);
     RUN_TEST(test_uart_writeOverflow);
+    vTaskDelay(10);
     RUN_TEST(test_uart_writeImmediate);
+    vTaskDelay(10);
     RUN_TEST(test_uart_writeImmediateStr);
+    vTaskDelay(10);
     RUN_TEST(test_uart_read);
+    vTaskDelay(10);
     RUN_TEST(test_uart_wordLen7);
+    vTaskDelay(10);
     RUN_TEST(test_uart_wordLen9);
+    vTaskDelay(10);
     RUN_TEST(test_uart_parity);
+    vTaskDelay(10);
     RUN_TEST(test_uart_stopbits);
+    vTaskDelay(10);
     RUN_TEST(test_uart_baudRate);
+    vTaskDelay(10);
     RUN_TEST(test_uart_overrun);
 
     return UNITY_END();


### PR DESCRIPTION
Created unit tests for:
- UART
- I2C
- SPI

Other changes:
- fixed i2c/spi bus off-by-one error
- added configuration validation to reject bad config settings
- added support for more baud rates
- added support for write_immediate and write_immediate_str
- updated doxygen docs
- added support for KUARTStatus